### PR TITLE
Make autoloader work correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "autoload": {
     "psr-0": {
-      "Lavender": "src"
+      "": "src/Lavender"
     }
   }
 }


### PR DESCRIPTION
This allows classloading without an explicit `require`. Instead, write this:

```
require 'vendor/autoload.php';
```
