### PR TITLE
Add support for @, : and . to the allowed characters for attributes

### DIFF
--- a/src/Lavender/extensions/html.php
+++ b/src/Lavender/extensions/html.php
@@ -75,7 +75,7 @@ class Lavender_Extension_Html extends Lavender_Node
           while ($content->peek() != '' && $content->peek() != ')') {
             $content->consume_regex("/[ \t\n]/i");
 
-            $name = $content->consume_regex("/[a-z0-9\-]/i");
+            $name = $content->consume_regex("/[a-z0-9\-@:\.]/i");
             $content->consume_whitespace();
             if ($content->peek() != '=') {
               throw new Lavender_Exception($content, 'expected "=" in attribute expression');


### PR DESCRIPTION
Vue.js uses the  @, : and . in the attribute name (https://vuejs.org/api/#v-on).
But Lavender does not allow this so that's why I would like that it will be supported in Lavender.
